### PR TITLE
Wrap modules in eval(  ... //@ sourceURL=modulePath) for easy debugging

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1071,7 +1071,7 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
     build.toTransport = function (anonDefRegExp, namespace, moduleName, path, contents, layer) {
 
         //If anonymous module, insert the module name.
-        return contents.replace(anonDefRegExp, function (match, start, callName, possibleComment, suffix, namedModule, namedFuncStart) {
+        var module = contents.replace(anonDefRegExp, function (match, start, callName, possibleComment, suffix, namedModule, namedFuncStart) {
             //A named module with either listed dependencies or an object
             //literal for a value. Skip it. If named module, only want ones
             //whose next argument is a function literal to scan for
@@ -1114,6 +1114,11 @@ function (lang,   logger,   file,          parse,    optimize,   pragma,
                    (deps ? ('[' + deps.toString() + '],') : '') +
                    (namedModule ? namedFuncStart.replace(build.leadingCommaRegExp, '') : suffix);
         });
+        
+        if(!/@ sourceURL/.test(module)) {
+             module = "eval(" + JSON.stringify(module + "\n//\@ sourceURL=" + path) + " )";
+        }
+        return module;
 
     };
 


### PR DESCRIPTION
SourceURL would be a very useful feature for built files. This isn't a proposed implementation, just a demo, so I've not added a switch or docs.

Example uses:
- JSTestDriver (no AMD support)
- anywhere you want to easily debug built files
- anywhere else without AMD support

Let me know if you'd value this feature, and that there's not major downsides I've missed, and I'll implement it properly.
