### PR TITLE
Allow to preserve important comments in minified CSS output while not using keepComments settings 

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -13353,6 +13353,9 @@ function (lang,   logger,   envOptimize,        file,           parse,
                              comment.indexOf('(c)') !== -1)) {
                             //Keep the comment, just increment the startIndex
                             startIndex = endIndex;
+                        } if (comment.indexOf('/*!')==0){
+                            // preserve comment that starts with /*!
+                            startIndex = endIndex;
                         } else {
                             fileContents = fileContents.substring(0, startIndex) + fileContents.substring(endIndex + 2, fileContents.length);
                             startIndex = 0;


### PR DESCRIPTION
Hi james,

In the recent project i was working on, i needed to keep some meta tag comment even after the CSS minification.

/*! 
- Example of sticky comments 
  */

This is pretty much in inline witht the what clean-css folks did (https://github.com/GoalSmashers/clean-css)

I hope someone could find it useful and we can integrate this

-seb
