### PR TITLE
Support generateSourceMaps and preserveLicenseComments when using uglify2

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1246,7 +1246,8 @@ define(function (require) {
         }
 
         if (config.generateSourceMaps) {
-            if (config.preserveLicenseComments && config.optimize !== 'none') {
+            if (config.preserveLicenseComments &&
+                !(config.optimize === 'none' || config.optimize === 'uglify2')) {
                 throw new Error('Cannot use preserveLicenseComments and ' +
                     'generateSourceMaps together, unless optimize is set ' +
                     'to \'uglify2\'. Either explcitly set preserveLicenseComments ' +

--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1248,10 +1248,10 @@ define(function (require) {
         if (config.generateSourceMaps) {
             if (config.preserveLicenseComments && config.optimize !== 'none') {
                 throw new Error('Cannot use preserveLicenseComments and ' +
-                    'generateSourceMaps together. Either explcitly set ' +
-                    'preserveLicenseComments to false (default is true) or ' +
-                    'turn off generateSourceMaps. If you want source maps with ' +
-                    'license comments, see: ' +
+                    'generateSourceMaps together, unless optimize is set ' +
+                    'to \'uglify2\'. Either explcitly set preserveLicenseComments ' +
+                    'to false (default is true) or turn off generateSourceMaps. ' +
+                    'If you want source maps with license comments, see: ' +
                     'http://requirejs.org/docs/errors.html#sourcemapcomments');
             } else if (config.optimize !== 'none' &&
                        config.optimize !== 'closure' &&

--- a/build/jslib/optimize.js
+++ b/build/jslib/optimize.js
@@ -253,6 +253,11 @@ function (lang,   logger,   envOptimize,        file,           parse,
                         }
                     }
 
+                    if (config.generateSourceMaps && licenseContents) {
+                        optConfig.preamble = licenseContents;
+                        licenseContents = '';
+                    }
+
                     fileContents = licenseContents + optFunc(fileName,
                                                              fileContents,
                                                              outFileName,
@@ -411,6 +416,7 @@ function (lang,   logger,   envOptimize,        file,           parse,
             uglify: function (fileName, fileContents, outFileName, keepLines, config) {
                 var parser = uglify.parser,
                     processor = uglify.uglify,
+                    preamble = config.preamble || "",
                     ast, errMessage, errMatch;
 
                 config = config || {};
@@ -440,7 +446,7 @@ function (lang,   logger,   envOptimize,        file,           parse,
                     }
                     throw new Error('Cannot uglify file: ' + fileName + '. Skipping it. Error is:\n' + errMessage);
                 }
-                return fileContents;
+                return preamble + fileContents;
             },
             uglify2: function (fileName, fileContents, outFileName, keepLines, config) {
                 var result, existingMap, resultMap, finalMap, sourceIndex,
@@ -453,6 +459,10 @@ function (lang,   logger,   envOptimize,        file,           parse,
                 lang.mixin(uconfig, config, true);
 
                 uconfig.fromString = true;
+
+                if (config.preamble) {
+                    uconfig.output = { preamble: config.preamble };
+                }
 
                 if (config.generateSourceMaps && (outFileName || config._buildSourceMap)) {
                     uconfig.outSourceMap = baseName;


### PR DESCRIPTION
Support using the generateSourceMaps and preserveLicenseComments options
together when using uglify2. Uses the preamble option of uglify2 to
include the license comments and have the source maps "adjust for its
presence".

I'm not sure if I should have implemented tests of this functionality or if I should have documented it otherwise, but then the approach might at least be useful.