### PR TITLE
Use stdout.write(..., 'utf8'), not stdout.setEncoding('utf8')

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -31077,8 +31077,7 @@ define('build', function (require) {
                     var out = new java.io.PrintStream(java.lang.System.out, true, 'UTF-8');
                     out.println(content);
                 } else if (e === 'node') {
-                    process.stdout.setEncoding('utf8');
-                    process.stdout.write(content);
+                    process.stdout.write(content, 'utf8');
                 } else {
                     console.log(content);
                 }


### PR DESCRIPTION
setEncoding() only really applies to readable streams
according to the docs. Use the encoding parameter in write
instead.

setEncoding() will actually result in a runtime error if used
when piping output to a file, because setEncoding() does not
exist when stdout is of type 'fs', contrary to when it is of
type 'tty'.
(See implementation and usage of createWritableStdioStream here:
https://github.com/nodejs/node/blob/2ba7baac93d8261d365412b5f000ea9a2de45a04/src/node.js)

You can run the following snippets to see that
process.stdout.setEncoding() should be avoided.

  node -e 'process.stdout.setEncoding("utf8")'

Works fine, because process.stdout is of type 'tty', but

  node -e 'process.stdout.setEncoding("utf8")' > foo

fails with error "TypeError: process.stdout.setEncoding is
not a function" because process.stdout is of type 'fs'.