### PR TITLE
Improve traverse and parse performance

### DIFF
--- a/build/jslib/parse.js
+++ b/build/jslib/parse.js
@@ -26,7 +26,7 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
 
     //From an esprima example for traversing its ast.
     function traverse(object, visitor) {
-        var key, child;
+        var child;
 
         if (!object) {
             return;
@@ -35,13 +35,11 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
         if (visitor.call(null, object) === false) {
             return false;
         }
-        for (key in object) {
-            if (object.hasOwnProperty(key)) {
-                child = object[key];
-                if (typeof child === 'object' && child !== null) {
-                    if (traverse(child, visitor) === false) {
-                        return false;
-                    }
+        for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
+            child = object[keys[i]];
+            if (typeof child === 'object' && child !== null) {
+                if (traverse(child, visitor) === false) {
+                    return false;
                 }
             }
         }
@@ -51,7 +49,7 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
     //stops that subtree analysis, not the rest of tree
     //visiting.
     function traverseBroad(object, visitor) {
-        var key, child;
+        var child;
 
         if (!object) {
             return;
@@ -60,12 +58,10 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
         if (visitor.call(null, object) === false) {
             return false;
         }
-        for (key in object) {
-            if (object.hasOwnProperty(key)) {
-                child = object[key];
-                if (typeof child === 'object' && child !== null) {
-                    traverseBroad(child, visitor);
-                }
+        for (var i = 0, keys = Object.keys(object); i < keys.length; i++) {
+            child = object[key];
+            if (typeof child === 'object' && child !== null) {
+                traverseBroad(child, visitor);
             }
         }
     }
@@ -212,7 +208,7 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
         //Like traverse, but skips if branches that would not be processed
         //after has application that results in tests of true or false boolean
         //literal values.
-        var key, child, result, i, params, param, tempObject,
+        var keys, child, result, i, params, param, tempObject,
             hasHas = options && options.has;
 
         fnExpScope = fnExpScope || emptyScope;
@@ -266,14 +262,12 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
                 }
             }
 
-            for (key in object) {
-                if (object.hasOwnProperty(key)) {
-                    child = object[key];
-                    if (typeof child === 'object' && child !== null) {
-                        result = this.recurse(child, onMatch, options, fnExpScope);
-                        if (typeof result === 'string') {
-                            break;
-                        }
+            for (i = 0, keys = Object.keys(object); i < keys.length; i++) {
+                child = object[keys[i]];
+                if (typeof child === 'object' && child !== null) {
+                    result = this.recurse(child, onMatch, options, fnExpScope);
+                    if (typeof result === 'string') {
+                        break;
                     }
                 }
             }


### PR DESCRIPTION
Make use of Object.keys rather than for..in + hasOwnProperty, as the
latter cannot be optimized by Node and results in deoptimized function
calls in the hot path.

Before:
```
   ticks  total  nonlib   name
    882    4.0%    4.0%  LazyCompile: ~traverse r.js:26797:22
    248    1.1%    1.1%  Stub: CEntryStub
    207    0.9%    0.9%  LazyCompile: *hasOwnProperty native v8natives.js:111:30
    194    0.9%    0.9%  LazyCompile: *ToName native runtime.js:466:16
    153    0.7%    0.7%  LazyCompile: ~parse.recurse r.js:26980:30
```
After:
```
   ticks  total  nonlib   name
     56    0.5%    0.5%  LazyCompile: *traverse r.js:26797:22
```

This has a significant impact on cpu time and wall clock performance. Test suites pass as far as I can tell, however the Rhino tests suites hung up on the sourcemap tests (they did on master as well). Not sure if it's required for this change but I have submitted a CLA just in case.