### PR TITLE
Fix dynamic define/needsDefine call generation for windows paths containing blackslashes

### DIFF
--- a/build/jslib/parse.js
+++ b/build/jslib/parse.js
@@ -128,11 +128,11 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
             astRoot = esprima.parse(fileContents);
 
         // Escape escape sequence in string literal for generating code on the fly
-        var escapeString = function (str) { 
+        var escapeString = function (str) {
             return str.replace(/\\/g, "\\\\");
         };
 
-        // Assemble define call with specified modulename and dependency string 
+        // Assemble define call with specified modulename and dependency string
         var makeDefineExpression = function (moduleName, depString) {
             return 'define("' + escapeString(moduleName) + '",' + depString + ');';
         };

--- a/build/tests/parse.js
+++ b/build/tests/parse.js
@@ -49,6 +49,7 @@ define(['parse', 'env!env/file', 'env'], function (parse, file, env) {
                 t.is('define("good2",["one","two"]);', parse("good2", "good2", good2));
                 t.is('define("good3",["one","two"]);', parse("good3", "good3", good3));
                 t.is('define("good4",["one","two"]);', parse("good4", "good4", good4));
+                t.is('define("a\\\\b\\\\c",["one","two"]);', parse("a\\b\\c", "good1", good1));
                 t.is('define("bad1",["me"]);', parse("bad1", "bad1", bad1));
                 t.is(null, parse("bad2", "bad2", bad2));
             }

--- a/dist/r.js
+++ b/dist/r.js
@@ -1,5 +1,5 @@
 /**
- * @license r.js 2.2.0 Copyright jQuery Foundation and other contributors.
+ * @license r.js 2.2.0 Mon, 11 Apr 2016 19:12:11 GMT Copyright jQuery Foundation and other contributors.
  * Released under MIT license, http://github.com/requirejs/r.js/LICENSE
  */
 
@@ -19,7 +19,7 @@ var requirejs, require, define, xpcUtil;
 (function (console, args, readFileFunc) {
     var fileName, env, fs, vm, path, exec, rhinoContext, dir, nodeRequire,
         nodeDefine, exists, reqMain, loadedOptimizedLib, existsForNode, Cc, Ci,
-        version = '2.2.0',
+        version = '2.2.0 Mon, 11 Apr 2016 19:12:11 GMT',
         jsSuffixRegExp = /\.js$/,
         commandOption = '',
         useLibLoaded = {},
@@ -21921,6 +21921,21 @@ define('parse', ['./esprimaAdapter', 'lang'], function (esprima, lang) {
             needsDefine = true,
             astRoot = esprima.parse(fileContents);
 
+        // Escape escape sequence in string literal for generating code on the fly
+        var escapeString = function (str) { 
+            return str.replace(/\\/g, "\\\\");
+        };
+
+        // Assemble define call with specified modulename and dependency string 
+        var makeDefineExpression = function (moduleName, depString) {
+            return 'define("' + escapeString(moduleName) + '",' + depString + ');';
+        };
+
+        // Assemble require.needsDefine expression with specified modulename
+        var makeRequireNeedsDefine = function (moduleName) {
+            return 'require.needsDefine("' + escapeString(moduleName) + '");';
+        };
+
         parse.recurse(astRoot, function (callName, config, name, deps, node, factoryIdentifier, fnExpScope) {
             if (!deps) {
                 deps = [];
@@ -21951,7 +21966,7 @@ define('parse', ['./esprimaAdapter', 'lang'], function (esprima, lang) {
         }, options);
 
         if (options.insertNeedsDefine && needsDefine) {
-            result += 'require.needsDefine("' + moduleName + '");';
+            result += makeRequireNeedsDefine(moduleName);
         }
 
         if (moduleDeps.length || moduleList.length) {
@@ -21970,15 +21985,14 @@ define('parse', ['./esprimaAdapter', 'lang'], function (esprima, lang) {
                 }
 
                 depString = arrayToString(moduleCall.deps);
-                result += 'define("' + moduleCall.name + '",' +
-                          depString + ');';
+                result += makeDefineExpression(moduleCall.name, depString);
             }
             if (moduleDeps.length) {
                 if (result) {
                     result += '\n';
                 }
                 depString = arrayToString(moduleDeps);
-                result += 'define("' + moduleName + '",' + depString + ');';
+                result += makeDefineExpression(moduleName, depString);
             }
         }
 

--- a/dist/r.js
+++ b/dist/r.js
@@ -1,5 +1,5 @@
 /**
- * @license r.js 2.2.0 Mon, 11 Apr 2016 19:12:11 GMT Copyright jQuery Foundation and other contributors.
+ * @license r.js 2.2.0 Mon, 11 Apr 2016 19:28:16 GMT Copyright jQuery Foundation and other contributors.
  * Released under MIT license, http://github.com/requirejs/r.js/LICENSE
  */
 
@@ -19,7 +19,7 @@ var requirejs, require, define, xpcUtil;
 (function (console, args, readFileFunc) {
     var fileName, env, fs, vm, path, exec, rhinoContext, dir, nodeRequire,
         nodeDefine, exists, reqMain, loadedOptimizedLib, existsForNode, Cc, Ci,
-        version = '2.2.0 Mon, 11 Apr 2016 19:12:11 GMT',
+        version = '2.2.0 Mon, 11 Apr 2016 19:28:16 GMT',
         jsSuffixRegExp = /\.js$/,
         commandOption = '',
         useLibLoaded = {},
@@ -21922,11 +21922,11 @@ define('parse', ['./esprimaAdapter', 'lang'], function (esprima, lang) {
             astRoot = esprima.parse(fileContents);
 
         // Escape escape sequence in string literal for generating code on the fly
-        var escapeString = function (str) { 
+        var escapeString = function (str) {
             return str.replace(/\\/g, "\\\\");
         };
 
-        // Assemble define call with specified modulename and dependency string 
+        // Assemble define call with specified modulename and dependency string
         var makeDefineExpression = function (moduleName, depString) {
             return 'define("' + escapeString(moduleName) + '",' + depString + ');';
         };


### PR DESCRIPTION
In requirePatch/dependency-resolving phase, module name generated for define/needsDefine calls on Windows were source path containing backslashes, such as `define("windows\paths\containing\backslashes", ["require"])`, most of the time define calls generated in this way happens to work, however silently triggering escape sequences would lead to unwanted behaviour.

For example, when processing sources named with a leading 'x', generated define call will be something like this:
``` define("some\path\to\xlib.js", ["require"]) ``` 

In this case, `"\x"` triggers an unresolvable hexadecimal escape sequence,  `eval(contents)` would lead to an uncaught syntax error (ILLEGAL TOKEN).

To make the code generation routine work correctly, string components in the generated calls should be correctly escaped, so that they would evaluate to expected string literals in the incoming eval() call.
