### PR TITLE
stdout.write uses encoding directly instead of setting encoding first

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -1341,8 +1341,7 @@ define(function (require) {
                     var out = new java.io.PrintStream(java.lang.System.out, true, 'UTF-8');
                     out.println(content);
                 } else if (e === 'node') {
-                    process.stdout.setEncoding('utf8');
-                    process.stdout.write(content);
+                    process.stdout.write(content, 'utf8');
                 } else {
                     console.log(content);
                 }


### PR DESCRIPTION
setEncoding() can be used only with stdout of type "tty". If the stdout is piped or redirected to file then it is of type "fs" and thus setEncoding fails. Specifying encoding directly as a stdout.write parameter solves the problem.

Following examples shows the problem. Following code works:

  node -e 'process.stdout.setEncoding("utf8")'

On the other hand this code fails with error "TypeError: process.stdout.setEncoding is not a function".

  node -e 'process.stdout.setEncoding("utf8")' > foo