### PR TITLE
Exclude dependencies in nonexistent files

### DIFF
--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -54,9 +54,14 @@ define(function (require) {
             d.resolve(require._cachedRawText[path]);
             return d.promise;
         } else {
-            return file.readFileAsync(path, encoding).then(function (text) {
-                require._cachedRawText[path] = text;
-                return text;
+            d = prim();
+            var beforeFileRead = require.s.contexts._.config.beforeFileRead;
+            d.resolve(beforeFileRead ? beforeFileRead(path, encoding) : undefined);
+            return d.promise.then(function (text) {
+                return typeof text !== 'undefined' ? text : file.readFileAsync(path, encoding).then(function (text) {
+                    require._cachedRawText[path] = text;
+                    return text;
+                });
             });
         }
     };

--- a/build/jslib/build.js
+++ b/build/jslib/build.js
@@ -543,6 +543,17 @@ define(function (require) {
                                 }
                             });
                         }
+                        if (module.excludeSpecific) {
+                            //module.excludeSpecific is a function, called for each remaining
+                            //dependency at any level, and if it returns a truthy value, the
+                            //dependency is removed.
+                            module.layer.buildFilePaths.slice(0).forEach(function (path) {
+                                var map = module.layer.buildFileToModule;
+                                if (module.excludeSpecific(path, map[path])) {
+                                    build.removeModulePath(map[file], path, module.layer);
+                                }
+                            });
+                        }
 
                         //Flatten them and collect the build output for each module.
                         return build.flattenModule(module, module.layer, config).then(function (builtModule) {


### PR DESCRIPTION
This pull request is perhaps best explained at the hand of the use case it resulted from.

I have one repository that contains the main code for the core of our application. Another repository contains the code for a plugin to the main application. The plugin contains imports for some of the core code, but this code does not exist on the repository at build time, though it will have been loaded once the plugin is loaded by the main application. The list of imports from the main repository is quite large, making it impractical to specify the list of exceptions (modules that will exist later, but don't now).

The desired functionality here would be for r.js to ask, on a per-module basis, whether or not a module should be included in the build. If not, it should not even attempt to access the file. Querying whether or not a module should be included as opposed to specifying the full list beforehand allows, for example, to exclude all modules in the /modules/ directory.

The implemented solution is two-fold.
The first patch provides a workaround (and some additional flexibility) to the fact that r.js always attempts to load a file from disk, even if the file is excluded. This causes an error for modules that don't exist at that stage. The solution is much the same as the rawText/paths option, but instead of specifying file contents beforehand, a beforeFileRead option allows dynamically specifying file contents before the file is loaded from disk.
The second part adds some additional flexibility when specifying the modules to exclude. Instead of excluding a module and all its dependencies, or just a module (which must be specified beforehand), a excludeSpecific option is created which is called once for every dependency and, if it returns true, the dependency is excluded.

It must be emphasized that specifying the list of modules to exclude beforehand is impractical as the list is large (and simply not available). It is, however, possible to know that all modules matching a certain regex should be excluded.

If indeed there is an easier way to do this, I'd love to hear it. If not, I imagine extra flexibility is always welcome, especially if it solves a practical use case such as this.