### PR TITLE
#988 Add layerName to builder writeAPI

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -30010,6 +30010,8 @@ define('build', function (require) {
                                         singleContents = config.onBuildWrite(moduleName, path, singleContents);
                                     }
                                 };
+                                //Add the layer name to the writeApi so builders know which layer is being built.
+                                writeApi.layerName = module.name;
                                 builder.write(parts.prefix, parts.name, writeApi);
                             }
                             return;


### PR DESCRIPTION
Suggestion implementation for my feature request #988. I only added the `layerName` as I don't really need the path, and passing a path to a file that's not yet (completely) generated may cause unexpected behavior for people writing plugin builders.