### PR TITLE
css optimisation : stop trying to inline css imports like //fonts.goo…

### DIFF
--- a/dist/r.js
+++ b/dist/r.js
@@ -27066,6 +27066,12 @@ function (lang,   logger,   envOptimize,        file,           parse,
             importFileName = importFileName.replace(lang.backSlashRegExp, "/");
 
             try {
+                //if an absolute path without scheme ex: //fonts.googleapis.com/icon?family=Material+Icons
+                //skip inlining, if not it will skip after 15seconds trying to readFile
+                if(importFileName.indexOf('//') === 0 ){
+                  logger.warn(fileName + "\n  Full path without scheme, Cannot inline css import, skipping: " + importFileName);
+                  return fullMatch;
+                }
                 //if a relative path, then tack on the filePath.
                 //If it is not a relative path, then the readFile below will fail,
                 //and we will just skip that import.


### PR DESCRIPTION
when css contains imports like  //fonts.googleapis.com/icon?family=Material+Icons
without http: or https: (which is totally valid)
the code try to load the file on the disk and abort after 15s.
With the current commit it will skip it directly
