### PR TITLE
Fixed the "Cannot read property 'type' of undefined" bug.

### DIFF
--- a/build/jslib/parse.js
+++ b/build/jslib/parse.js
@@ -938,7 +938,7 @@ define(['./esprimaAdapter', 'lang'], function (esprima, lang) {
             //if that has a define.amd test
             if (bodyNode.consequent && bodyNode.consequent.body) {
                 exp = bodyNode.consequent.body[0];
-                if (exp.type === 'ExpressionStatement' && exp.expression &&
+                if (exp && exp.type === 'ExpressionStatement' && exp.expression &&
                     parse.hasDefine(exp.expression) &&
                     exp.expression.arguments &&
                     exp.expression.arguments.length === 1 &&


### PR DESCRIPTION
In my project I got an error while processing one of the files:
```
...
  originalError: [Error: Parse error using esprima for file: /opt/app/src/app/vendor/istream-widget/istream-widget.js
  TypeError: Cannot read property 'type' of undefined
...
```

I investigated the problem and got to the line with if statement where the `exp.type` expression is compared to the string literal 'ExpressionStatement'. In some cases variable `exp` is undefined. I added a simple check for variable existence (truthiness) as an additional condition to the if statement.

A similar comparison with 'AssignmentExpression' literal is done originally in another fragment of code but in that case, proper check for variable existence (truthiness) is present.